### PR TITLE
[add] 업로드 동영상 리스트 가져오기 기능 [#34]

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,9 @@ dependencies {
     // Bzip2 파일 압축
     implementation 'org.apache.commons:commons-compress:1.21'
 
+    //db에 파일 저장
+    implementation 'commons-fileupload:commons-fileupload:1.3.3'
+
 }
 
 test {

--- a/src/main/java/com/dalcho/adme/controller/VideoController.java
+++ b/src/main/java/com/dalcho/adme/controller/VideoController.java
@@ -1,13 +1,17 @@
 package com.dalcho.adme.controller;
 
+import com.dalcho.adme.domain.VideoFile;
 import com.dalcho.adme.dto.VideoDto;
 import com.dalcho.adme.service.VideoService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @Controller
@@ -16,11 +20,15 @@ public class VideoController {
 
     public final VideoService videoService;
 
-    @PostMapping(value = "/10s/videos")
-    public String uploadFile(@RequestParam("uploadFile") MultipartFile file, VideoDto dto) throws Exception {
-        log.info("VideoController");
-        // @ModelAttribute 가 default 값
-        videoService.uploadFile(file, dto);
-        return "tenseconds";
+    @GetMapping( "/tenseconds/list" )
+    public List<VideoFile> listFiles() throws Exception {
+        log.info("VideoController GetList");
+        return videoService.getList();
+    }
+
+    @PostMapping(value = "/tenseconds/videos")
+    public VideoFile uploadFile(@RequestParam("uploadFile") MultipartFile file, VideoDto dto) throws Exception {
+        log.info("VideoController Post");
+        return videoService.uploadFile(file, dto);
     }
 }

--- a/src/main/java/com/dalcho/adme/domain/VideoFile.java
+++ b/src/main/java/com/dalcho/adme/domain/VideoFile.java
@@ -24,15 +24,23 @@ public class VideoFile {
     private String uploadPath;
 
     @Column(nullable = false)
-    private String image;
+    private Long fileSize; // 파일 사이즈 바이트 수
 
-//    @Column(nullable = false)
-//    private String videoDate;
+    @Column(nullable = false)
+    private String fileType; // 파일 확장자
+
+    @Column(nullable = false)
+    private byte[] fileData; // 실제 파일 데티어
+
+    @Column(nullable = false)
+    private String videoDate;
 
     public VideoFile(VideoDto videoDto) {
         this.fileName = videoDto.getFileName();
         this.uploadPath = String.valueOf(videoDto.getUploadPath());
-        this.image = String.valueOf(videoDto.getImage());
-//        this.videoDate = String.valueOf(videoDto.getVideoDate());
+        this.fileSize = videoDto.getFileSize();
+        this.fileType = videoDto.getFileType();
+        this.fileData = videoDto.getFileData();
+        this.videoDate = String.valueOf(videoDto.getVideoDate());
     }
 }

--- a/src/main/java/com/dalcho/adme/dto/VideoDto.java
+++ b/src/main/java/com/dalcho/adme/dto/VideoDto.java
@@ -3,10 +3,14 @@ package com.dalcho.adme.dto;
 import lombok.Data;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
+
 @Data
 public class VideoDto {
     private String fileName;
     private String uploadPath;
-    private MultipartFile image;
-//    private LocalDateTime videoDate;
+    private Long fileSize;
+    private String fileType;
+    private byte[] fileData;
+    private LocalDateTime videoDate;
 }

--- a/src/main/java/com/dalcho/adme/service/VideoService.java
+++ b/src/main/java/com/dalcho/adme/service/VideoService.java
@@ -4,6 +4,9 @@ import com.dalcho.adme.domain.VideoFile;
 import com.dalcho.adme.dto.VideoDto;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.util.List;
+
 public interface VideoService {
     VideoFile uploadFile(MultipartFile file, VideoDto dto) throws Exception;
+    List<VideoFile> getList() throws Exception;
 }


### PR DESCRIPTION
+동영상 데이터를 DB에 저장기능 구현
+DB의 데이터 List로 GET 기능 구현
(DB에서 데이터를 가져오는데 어려움이 있어 동영상 데이터는 로컬 저장소(static) 폴더에서 가져와 리스트를 띄워주는 형식으로 구현해 놨습니다.)

해결 해야할 문제. 
로컬 저장소(static)에 저장시 intelij 동작시에 1회성으로 폴더의 값을 읽어온다.
-> 만약 이미 동작하고 있을때 파일을 업로드하면 그 해당 파일이 폴더에 올라간다 해도 읽어오지 못한다.
     다시 돌리면 파일 내용을 읽어와 띄워주긴 한다.

[추후 고려사항]
s3서버를 만들어 저장 및 가져오기 구현 
또는 
db에 저장된 데이터를 가져오는 방식 구현