### PR TITLE
[add & update] Video 후처리 및 Thumbnail 저장

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,12 +41,11 @@ dependencies {
     // Bzip2 파일 압축
     implementation 'org.apache.commons:commons-compress:1.21'
 
-    //db에 파일 저장
+    // db에 파일 저장
     implementation 'commons-fileupload:commons-fileupload:1.3.3'
 
-    //동영상 인코더
+    // 동영상 인코더
     implementation 'net.bramp.ffmpeg:ffmpeg:0.6.2'
-
 }
 
 test {

--- a/src/main/java/com/dalcho/adme/controller/VideoController.java
+++ b/src/main/java/com/dalcho/adme/controller/VideoController.java
@@ -32,17 +32,10 @@ public class VideoController {
 
     @PostMapping("/tenSeconds/videos")
     public VideoResultDto uploadFile(@AuthenticationPrincipal User user, @RequestPart(name = "sideData") VideoRequestDto requestDto,
-                                     @RequestPart(name = "videoFile") MultipartFile file) throws Exception {
+                                     @RequestPart(name = "videoFile") MultipartFile file, @RequestPart(name = "thumbnail") MultipartFile thumbnail) throws Exception {
         log.info("[VideoController] uploadFile() ");
-        return videoService.uploadFile(user, requestDto, file);
+        return videoService.uploadFile(user, requestDto, file, thumbnail);
     }
-
-//    @PutMapping("/tenSeconds/video/{id}")
-//    public VideoResultDto update(@PathVariable Long id, @RequestPart(name = "updateSideData") VideoRequestDto requestDto,
-//                                 @RequestPart(name = "updateVideoFile") MultipartFile file) throws IOException {
-//        log.info("[VideoController] update");
-//        return videoService.update(id, requestDto, file);
-//    }
 
     @PutMapping("/tenSeconds/video/{id}")
     public VideoResultDto update(@PathVariable Long id, @RequestPart(name = "updateData") VideoRequestDto requestDto) throws IOException {

--- a/src/main/java/com/dalcho/adme/controller/VideoController.java
+++ b/src/main/java/com/dalcho/adme/controller/VideoController.java
@@ -38,9 +38,9 @@ public class VideoController {
     }
 
     @PutMapping("/tenSeconds/video/{id}")
-    public VideoResultDto update(@PathVariable Long id, @RequestPart(name = "updateData") VideoRequestDto requestDto) throws IOException {
+    public VideoResultDto update(@PathVariable Long id, @RequestPart(name = "updateData") VideoRequestDto requestDto, @RequestPart(name = "thumbnail") MultipartFile thumbnail) throws IOException {
         log.info("[VideoController] update");
-        return videoService.update(id, requestDto);
+        return videoService.update(id, requestDto, thumbnail);
     }
 
     @DeleteMapping("/tenSeconds/video/{id}")

--- a/src/main/java/com/dalcho/adme/domain/VideoFile.java
+++ b/src/main/java/com/dalcho/adme/domain/VideoFile.java
@@ -28,6 +28,9 @@ public class VideoFile {
     private String uploadPath;
 
     @Column(nullable = false)
+    private String thumbnailExt = "png";
+
+    @Column(nullable = false)
     private LocalDateTime videoDate;
 
     @ManyToOne(fetch = FetchType.LAZY)
@@ -46,12 +49,17 @@ public class VideoFile {
         }
     }
 
+    public void setThumbnailExt(String thumbnailExt){
+        this.thumbnailExt = thumbnailExt;
+    }
+
     @Builder
-    public VideoFile(String title, String content, String uuid, String uploadPath, LocalDateTime videoDate) {
+    public VideoFile(String title, String content, String uuid, String uploadPath, String thumbnailExt, LocalDateTime videoDate) {
         this.title = title;
         this.content = content;
         this.uuid = uuid;
         this.uploadPath = uploadPath;
+        this.thumbnailExt = thumbnailExt;
         this.videoDate = videoDate;
     }
 

--- a/src/main/java/com/dalcho/adme/exception/ErrorCode.java
+++ b/src/main/java/com/dalcho/adme/exception/ErrorCode.java
@@ -16,6 +16,7 @@ public enum ErrorCode {
     // Video
     FILE_NOT_FOUND(HttpStatus.NOT_FOUND, "파일을 찾을 수 없습니다."),
     FILE_NAME_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 파일의 이름이 존재하지 않습니다."),
+    INVALID_EXTENSION(HttpStatus.UNAUTHORIZED, "파일의 형식이 잘못되었습니다."),
 
     // Registry
     REGISTRY_NOT_FOUND(HttpStatus.NOT_FOUND, "게시글이 존재하지 않습니다."),

--- a/src/main/java/com/dalcho/adme/exception/invalid/InvalidExtensionException.java
+++ b/src/main/java/com/dalcho/adme/exception/invalid/InvalidExtensionException.java
@@ -1,0 +1,10 @@
+package com.dalcho.adme.exception.invalid;
+
+import com.dalcho.adme.exception.CustomException;
+import com.dalcho.adme.exception.ErrorCode;
+
+public class InvalidExtensionException extends CustomException {
+    public InvalidExtensionException() {
+        super(ErrorCode.INVALID_EXTENSION);
+    }
+}

--- a/src/main/java/com/dalcho/adme/service/VideoService.java
+++ b/src/main/java/com/dalcho/adme/service/VideoService.java
@@ -13,6 +13,6 @@ import java.util.List;
 public interface VideoService {
     VideoResultDto uploadFile(User user, VideoRequestDto videoRequestDto, MultipartFile file, MultipartFile thumbnail) throws Exception;
     List<VideoResponseDto> getList(Pageable pageable) throws Exception;
-    VideoResultDto update(Long id, VideoRequestDto videoRequestDto) throws IOException;
+    VideoResultDto update(Long id, VideoRequestDto videoRequestDto, MultipartFile thumbnail) throws IOException;
     void delete(Long id);
 }

--- a/src/main/java/com/dalcho/adme/service/VideoService.java
+++ b/src/main/java/com/dalcho/adme/service/VideoService.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 import java.util.List;
 
 public interface VideoService {
-    VideoResultDto uploadFile(User user, VideoRequestDto videoRequestDto, MultipartFile file) throws Exception;
+    VideoResultDto uploadFile(User user, VideoRequestDto videoRequestDto, MultipartFile file, MultipartFile thumbnail) throws Exception;
     List<VideoResponseDto> getList(Pageable pageable) throws Exception;
     VideoResultDto update(Long id, VideoRequestDto videoRequestDto) throws IOException;
     void delete(Long id);

--- a/src/main/java/com/dalcho/adme/utils/video/ExtCheckUtils.java
+++ b/src/main/java/com/dalcho/adme/utils/video/ExtCheckUtils.java
@@ -1,0 +1,30 @@
+package com.dalcho.adme.utils.video;
+
+import com.dalcho.adme.exception.invalid.InvalidExtensionException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ExtCheckUtils {
+    public static String extractionExt(MultipartFile thumbnail) {
+        String mimeType = thumbnail.getContentType();
+        checkExt(mimeType);
+        return mimeType.substring(mimeType.lastIndexOf("/") + 1);
+    }
+
+    private static void checkExt(String mimeType) {
+        final List<String> PERMISSION_FILE_MIME_TYPE = Arrays.asList("image/gif", "image/jpeg", "image/png");
+
+        if (!PERMISSION_FILE_MIME_TYPE.contains(mimeType)){
+            throw new InvalidExtensionException();
+        }
+
+        log.info("[checkExt] 확장자 체크 완료");
+    }
+
+}

--- a/src/main/java/com/dalcho/adme/utils/video/VideoUtils.java
+++ b/src/main/java/com/dalcho/adme/utils/video/VideoUtils.java
@@ -9,6 +9,8 @@ import net.bramp.ffmpeg.FFprobe;
 import net.bramp.ffmpeg.builder.FFmpegBuilder;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.imageio.ImageIO;
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -19,7 +21,7 @@ import java.nio.file.Paths;
 public class VideoUtils {
 
     public static void saveFile(MultipartFile file, VideoFile videoFile) {
-        log.info("[VideoUtils] saveFile 수행");
+        log.info("[VideoUtils] saveFile");
 
         Path path = Paths.get(videoFile.getUploadPath());
 
@@ -33,10 +35,29 @@ public class VideoUtils {
         } catch (IOException e) {
             throw new IllegalStateException("failed to save file. " + videoFile.getUuid(), e);
         }
+
+        log.info("[VideoUtils] saveFile Completed!");
+    }
+
+    public static void saveThumbnail(VideoFile videoFile, MultipartFile thumbnail) throws IOException {
+        log.info("[VideoUtils] saveThumbnail");
+
+        BufferedImage thumbImage = ImageIO.read(thumbnail.getInputStream());
+        int width = thumbImage.getWidth();
+        int height = thumbImage.getHeight();
+        // 이미지 16:9 로 편집
+        BufferedImage croppedImage = (thumbImage.getHeight() > thumbImage.getWidth() ?
+                thumbImage.getSubimage((width/2) - (height / 18 * 16), 0, height / 9 * 16, height) :
+                thumbImage.getSubimage(0, (height/2) - (width / 32 * 9), width, width / 16 * 9));
+
+        File outputFile = new File(videoFile.getUploadPath() + File.separator + "thumb_" + videoFile.getUuid() + ".jpg");
+        ImageIO.write(croppedImage, "jpg", outputFile);
+
+        log.info("[VideoUtils] saveThumbnail Completed!");
     }
 
     public static void deleteFile(VideoFile videoFile) {
-        log.info("[VideoUtils] deleteFile 수행");
+        log.info("[VideoUtils] deleteFile");
 
         Path ten = Paths.get(videoFile.getUploadPath() + File.separator + "ten_" + videoFile.getUuid() + ".mp4");
         Path thumb = Paths.get(videoFile.getUploadPath() + File.separator + "thumb_" + videoFile.getUuid() + ".jpg");
@@ -47,6 +68,7 @@ public class VideoUtils {
         } catch (IOException e) {
             throw new IllegalStateException("failed to delete file. " + videoFile.getUuid(), e);
         }
+        log.info("[VideoUtils] deleteFile Completed!");
     }
 
     public static void createVideo(String ffmpegPath, String ffprobePath, VideoFile videoFile , int setTime) throws IOException {
@@ -56,19 +78,24 @@ public class VideoUtils {
         FFprobe ffprobe = new FFprobe(ffprobePath);
 
         FFmpegBuilder fFmpegBuilder = new FFmpegBuilder()
-                .overrideOutputFiles(true)
-                .addInput(videoFile.getUploadPath() + videoFile.getUuid() + ".mp4")
-                .addExtraArgs("-ss", String.valueOf(setTime))
-                .addExtraArgs("-t", String.valueOf(setTime+10))
-                .addOutput(videoFile.getUploadPath() + "ten_" + videoFile.getUuid() + ".mp4")
+                .setInput(videoFile.getUploadPath() + videoFile.getUuid() + ".mp4") // 변환 할 파일 위치 설정
+                .overrideOutputFiles(true) // 덮어쓰기 설정
+                .addExtraArgs("-ss", String.valueOf(setTime)) // 영상 자를 위치 설정
+                .addExtraArgs("-t", String.valueOf(10)) // 영상 길이 설정
+                .addOutput(videoFile.getUploadPath() + "ten_" + videoFile.getUuid() + ".mp4") // 변환 된 파일 위치 설정
+                .setFormat("mp4") // 확장자
+                .setVideoResolution(1280, 720) // 비디오 해상도 설정
+                .setVideoFrameRate(30) // 프레임 설정
+                .setVideoBitRate(3000 * 1000) // 비트 레이트 설정 (화질 설정)
                 .done();
 
         FFmpegExecutor executor = new FFmpegExecutor(ffmpeg, ffprobe);
         executor.createJob(fFmpegBuilder).run();
+
+        log.info("[VideoUtils] createVideo Completed!");
     }
 
-    public static void createThumbnail(String ffmpegPath, String ffprobePath, VideoFile videoFile) throws IOException {
-
+    public static void createThumbnail(String ffmpegPath, String ffprobePath, VideoFile videoFile, int setTime) throws IOException {
         log.info("[VideoUtils] createThumbnail");
 
         FFmpeg ffmpeg = new FFmpeg(ffmpegPath);
@@ -77,22 +104,25 @@ public class VideoUtils {
         FFmpegBuilder builder = new FFmpegBuilder()
                 .overrideOutputFiles(true) // 출력이 있는경우 덮어쓰기
                 .setInput(videoFile.getUploadPath() + videoFile.getUuid() + ".mp4") // 썸네일 생성대상 파일
-                .addExtraArgs("-ss", "00:00:01") // 썸네일 추출 시작점
+                .addExtraArgs("-ss", String.valueOf(setTime)) // 썸네일 추출 시작점
                 .addOutput(videoFile.getUploadPath() + "thumb_" + videoFile.getUuid() + ".jpg") // 썸네일 파일을 저장할 위치
                 .setFrames(1) // 프레임 수
                 .done();
 
         FFmpegExecutor executor = new FFmpegExecutor(ffmpeg, ffprobe);
         executor.createJob(builder).run();
+
+        log.info("[VideoUtils] createThumbnail Completed!");
     }
 
     public static void deleteVideo(VideoFile videoFile) {
-        log.info("[VideoUtils] deleteVideo 수행");
+        log.info("[VideoUtils] deleteVideo");
 
         Path path = Paths.get(videoFile.getUploadPath() + File.separator + videoFile.getUuid() + ".mp4");
 
         try {
             Files.delete(path);
+            log.info("[VideoUtils] deleteVideo Completed!");
         } catch (IOException e) {
             throw new IllegalStateException("failed to delete file. " + videoFile.getUuid(), e);
         }

--- a/src/main/java/com/dalcho/adme/utils/video/VideoUtils.java
+++ b/src/main/java/com/dalcho/adme/utils/video/VideoUtils.java
@@ -45,30 +45,16 @@ public class VideoUtils {
         BufferedImage thumbImage = ImageIO.read(thumbnail.getInputStream());
         int width = thumbImage.getWidth();
         int height = thumbImage.getHeight();
-        // 이미지 16:9 로 편집
-        BufferedImage croppedImage = (thumbImage.getHeight() > thumbImage.getWidth() ?
-                thumbImage.getSubimage((width/2) - (height / 18 * 16), 0, height / 9 * 16, height) :
-                thumbImage.getSubimage(0, (height/2) - (width / 32 * 9), width, width / 16 * 9));
 
-        File outputFile = new File(videoFile.getUploadPath() + File.separator + "thumb_" + videoFile.getUuid() + ".jpg");
-        ImageIO.write(croppedImage, "jpg", outputFile);
+        // 이미지 16:9 로 편집
+        BufferedImage croppedImage = thumbImage.getHeight() >= thumbImage.getWidth()  ?
+                thumbImage.getSubimage(0, (height/2)-((width/32)*9), width, (width/16)*9) :
+                thumbImage.getSubimage((width/2)-((height/18)*16), 0, (height/9)*16, height);
+
+        File outputFile = new File(videoFile.getUploadPath() + File.separator + "thumb_" + videoFile.getUuid() + "." + videoFile.getThumbnailExt());
+        ImageIO.write(croppedImage, videoFile.getThumbnailExt(), outputFile);
 
         log.info("[VideoUtils] saveThumbnail Completed!");
-    }
-
-    public static void deleteFile(VideoFile videoFile) {
-        log.info("[VideoUtils] deleteFile");
-
-        Path ten = Paths.get(videoFile.getUploadPath() + File.separator + "ten_" + videoFile.getUuid() + ".mp4");
-        Path thumb = Paths.get(videoFile.getUploadPath() + File.separator + "thumb_" + videoFile.getUuid() + ".jpg");
-
-        try {
-            Files.delete(ten);
-            Files.delete(thumb);
-        } catch (IOException e) {
-            throw new IllegalStateException("failed to delete file. " + videoFile.getUuid(), e);
-        }
-        log.info("[VideoUtils] deleteFile Completed!");
     }
 
     public static void createVideo(String ffmpegPath, String ffprobePath, VideoFile videoFile , int setTime) throws IOException {
@@ -105,7 +91,7 @@ public class VideoUtils {
                 .overrideOutputFiles(true) // 출력이 있는경우 덮어쓰기
                 .setInput(videoFile.getUploadPath() + videoFile.getUuid() + ".mp4") // 썸네일 생성대상 파일
                 .addExtraArgs("-ss", String.valueOf(setTime)) // 썸네일 추출 시작점
-                .addOutput(videoFile.getUploadPath() + "thumb_" + videoFile.getUuid() + ".jpg") // 썸네일 파일을 저장할 위치
+                .addOutput(videoFile.getUploadPath() + "thumb_" + videoFile.getUuid() + "." + videoFile.getThumbnailExt()) // 썸네일 파일을 저장할 위치
                 .setFrames(1) // 프레임 수
                 .done();
 
@@ -127,4 +113,46 @@ public class VideoUtils {
             throw new IllegalStateException("failed to delete file. " + videoFile.getUuid(), e);
         }
     }
+
+    public static void deleteTen(VideoFile videoFile) {
+        log.info("[VideoUtils] deleteTen");
+
+        Path ten = Paths.get(videoFile.getUploadPath() + File.separator + "ten_" + videoFile.getUuid() + ".mp4");
+
+        try {
+            Files.delete(ten);
+        } catch (IOException e) {
+            throw new IllegalStateException("failed to delete file. " + videoFile.getUuid(), e);
+        }
+        log.info("[VideoUtils] deleteTen Completed!");
+    }
+
+    public static void deleteThumb(VideoFile videoFile) {
+        log.info("[VideoUtils] deleteThumb");
+
+        Path thumb = Paths.get(videoFile.getUploadPath() + File.separator + "thumb_" + videoFile.getUuid() + "." + videoFile.getThumbnailExt());
+
+        try {
+            Files.delete(thumb);
+        } catch (IOException e) {
+            throw new IllegalStateException("failed to delete file. " + videoFile.getUuid(), e);
+        }
+        log.info("[VideoUtils] deleteThumb Completed!");
+    }
+
+    public static void deleteFiles(VideoFile videoFile) {
+        log.info("[VideoUtils] deleteFiles");
+
+        Path ten = Paths.get(videoFile.getUploadPath() + File.separator + "ten_" + videoFile.getUuid() + ".mp4");
+        Path thumb = Paths.get(videoFile.getUploadPath() + File.separator + "thumb_" + videoFile.getUuid() + "." + videoFile.getThumbnailExt());
+
+        try {
+            Files.delete(ten);
+            Files.delete(thumb);
+        } catch (IOException e) {
+            throw new IllegalStateException("failed to delete file. " + videoFile.getUuid(), e);
+        }
+        log.info("[VideoUtils] deleteFiles Completed!");
+    }
+
 }


### PR DESCRIPTION
[Add]
- Video 화질 설정
    - 해상도 설정 (1280*720)
    - 프레임 설정 (30fps)
    - 비트레이 설정 (3000kbps)
- Thumbnail 처리
    - thumbnail 개별로 저장 가능 ( 16:9 비율로 잘라서 저장 ) 
    - thumbnail 이 없을경우 setTime 시간의 가장 첫부분으로 설정
    - thumbnail 변경 구현
  

[Update]
- 개시물 수정 처리
    - 10s 생성 시간대 수정 및 thumbnail 이미지 변경 값 유무에 따라 처리