### PR TITLE
[코드 수정] 채팅 마지막 글 가져오기 수정

### DIFF
--- a/src/main/java/com/dalcho/adme/controller/chat/ChatRoomController.java
+++ b/src/main/java/com/dalcho/adme/controller/chat/ChatRoomController.java
@@ -1,6 +1,7 @@
 package com.dalcho.adme.controller.chat;
 
 import com.dalcho.adme.config.security.JwtTokenProvider;
+import com.dalcho.adme.dto.LastMessage;
 import com.dalcho.adme.dto.chat.ChatMessage;
 import com.dalcho.adme.dto.chat.ChatRoomDto;
 import com.dalcho.adme.service.Impl.ChatServiceImpl;
@@ -50,7 +51,7 @@ public class ChatRoomController {
         chatService.saveFile(chatMessage);
     }
     @GetMapping ("/room/enter/{roomId}")
-    List<String> lastLine(@PathVariable String roomId) {
+    LastMessage lastLine(@PathVariable String roomId) {
         return chatService.lastLine(roomId);
     }
 

--- a/src/main/java/com/dalcho/adme/dto/chat/ChatRoomDto.java
+++ b/src/main/java/com/dalcho/adme/dto/chat/ChatRoomDto.java
@@ -2,6 +2,7 @@ package com.dalcho.adme.dto.chat;
 
 import com.dalcho.adme.domain.Chat;
 import com.dalcho.adme.domain.User;
+import com.dalcho.adme.dto.LastMessage;
 import lombok.*;
 
 import java.io.Serializable;
@@ -14,30 +15,34 @@ import java.util.UUID;
 @Builder
 @AllArgsConstructor
 public class ChatRoomDto implements Serializable { // 일반 crud에서 쓰임
-	private String roomId; // 채팅방 아이디
-	private String roomName; // 채팅방 이름(사용자가 설정한 이름)
-	private String nickname;
-	private Integer adminChat;
-	private Integer userChat;
-	private String message;
+    private String roomId; // 채팅방 아이디
+    private String roomName; // 채팅방 이름(사용자가 설정한 이름)
+    private String nickname;
+    private Integer adminChat;
+    private Integer userChat;
+    private String message;
+    private String day;
+    private String time;
 
-	public ChatRoomDto() {
-	}
+    public ChatRoomDto() {
+    }
 
-	public static ChatRoomDto create(String name) {
-		ChatRoomDto room = new ChatRoomDto();
-		room.roomId = UUID.randomUUID().toString();
-		room.roomName = name;
-		return room;
-	}
+    public static ChatRoomDto create(String name) {
+        ChatRoomDto room = new ChatRoomDto();
+        room.roomId = UUID.randomUUID().toString();
+        room.roomName = name;
+        return room;
+    }
 
-	public static ChatRoomDto of(String roomId, String nickname, User user, List<String> list) {
-		return ChatRoomDto.builder()
-				.roomId(roomId)
-				.nickname(user.getNickname())
-				.adminChat(Integer.valueOf(list.get(0)))
-				.userChat(Integer.valueOf(list.get(1)))
-				.message(list.get(2))
-				.build();
-	}
+    public static ChatRoomDto of(String roomId, User user, LastMessage lastMessage) {
+        return ChatRoomDto.builder()
+                .roomId(roomId)
+                .nickname(user.getNickname())
+                .adminChat(lastMessage.getAdminChat())
+                .userChat(lastMessage.getUserChat())
+                .message(lastMessage.getMessage())
+                .day(lastMessage.getDay())
+                .time(lastMessage.getTime())
+                .build();
+    }
 }

--- a/src/main/java/com/dalcho/adme/oauth2/OAuth2SuccessHandler.java
+++ b/src/main/java/com/dalcho/adme/oauth2/OAuth2SuccessHandler.java
@@ -47,13 +47,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 		String token = jwtProvider.generateToken(user);
 
 		log.info("[Oauth Success Handler] 쿠키 생성");
-		Cookie idCookie = new Cookie("TokenCookie", token);
-		idCookie.setPath("/"); // 모든 경로에서 접근 가능
-		idCookie.setDomain("localhost");
-		idCookie.setMaxAge(24 * 60 * 60); // 1day
-		//idCookie.setSecure(true);
-		response.addCookie(idCookie);
-		log.info("[oauth] 쿠키 생성 완료");
 
 		UserDetails userDetails = userDetailService.loadUserByUsername(jwtProvider.getNickname(token));
 		UsernamePasswordAuthenticationToken auth =

--- a/src/main/java/com/dalcho/adme/service/Impl/ChatServiceImpl.java
+++ b/src/main/java/com/dalcho/adme/service/Impl/ChatServiceImpl.java
@@ -4,6 +4,7 @@ import com.dalcho.adme.domain.Chat;
 import com.dalcho.adme.domain.User;
 import com.dalcho.adme.dto.LastMessage;
 import com.dalcho.adme.dto.chat.ChatMessage;
+import com.dalcho.adme.dto.chat.ChatMessage.MessageType;
 import com.dalcho.adme.dto.chat.ChatRoomDto;
 import com.dalcho.adme.dto.chat.ChatRoomMap;
 import com.dalcho.adme.exception.notfound.FileNotFoundException;
@@ -19,8 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.cache.annotation.Cacheable;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.cache.annotation.CachePut;
 import org.springframework.stereotype.Service;
 
 import javax.annotation.PostConstruct;
@@ -30,274 +30,292 @@ import java.nio.file.NoSuchFileException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
 public class ChatServiceImpl {
-	private final ChatRepository chatRepository;
-	private Map<String, Integer> connectUsers;
-	private Map<String, Integer> adminChat;
-	private Map<String, Integer> userChat;
-	private final RedisTemplate<String, ChatRoomDto> redisTemplate;
-	@Value("${chat.file}")
-	private String chatUploadLocation;
-	private final UserRepository userRepository;
-	private final Object lock = new Object();
-	private Map<String, LastMessage> lastMessageMap;
+    private final ChatRepository chatRepository;
+    private Map<String, Integer> connectUsers;
+    private Map<String, Integer> adminChat;
+    private Map<String, Integer> userChat;
 
-	@PostConstruct
-	private void setUp() {
-		this.connectUsers = new HashMap<>();
-		this.adminChat = new HashMap<>();
-		this.userChat = new HashMap<>();
-		this.lastMessageMap = new HashMap<>();
-	}
+    @Value("${chat.file}")
+    private String chatUploadLocation;
+    private final UserRepository userRepository;
+    private final Object lock = new Object();
 
-	public void connectUser(String status, String roomId, ChatMessage chatMessage) {
-		int num = 0;
-		synchronized (lock) {
-			if (Objects.equals(status, "Connect")) {
-				connectUsers.putIfAbsent(roomId, 0);
-				num = connectUsers.get(roomId);
-				connectUsers.put(roomId, (num + 1));
-				saveFile(chatMessage);
-			} else if (Objects.equals(status, "Disconnect")) {
-				num = connectUsers.get(roomId);
-				connectUsers.put(roomId, (num - 1));
-			}
-			log.info("현재 인원 : " + connectUsers.get(roomId));
-		}
-	}
+    private Map<String, LastMessage> lastMessageMap;
 
-	//채팅방 불러오기
-	public List<ChatRoomDto> findAllRoom(){
-		List<ChatRoomDto> chatRoomDtos = new ArrayList<>();
-		List<Chat> all = chatRepository.findAll();
-		try {
-			for (int i = 0; i < all.size(); i++) {
-				User user = userRepository.findById(all.get(i).getUser().getId()).orElseThrow(UserNotFoundException::new);
-				chatRoomDtos.add(ChatRoomDto.of(all.get(i).getRoomId(), user.getNickname(), user, lastLine(all.get(i).getRoomId())));
-			}
-		} catch (NullPointerException e) {
-			log.info(" [현재 채팅방 db 없음!] " + e);
-		}
-		return chatRoomDtos;
-	}
+    @PostConstruct
+    private void setUp() {
+        this.connectUsers = new ConcurrentHashMap<>();
+        this.adminChat = new HashMap<>();
+        this.userChat = new HashMap<>();
+        this.lastMessageMap = new HashMap<>();
+    }
 
-	//채팅방 생성
-	@Cacheable(key = "#nickname", value = "createRoom", unless = "#result == null", cacheManager = "cacheManager")
-	public ChatRoomDto createRoom(String nickname) {
-		long startTime = System.currentTimeMillis();
-		User user = userRepository.findByNickname(nickname).orElseThrow(UserNotFoundException::new);
-		ChatRoomDto chatRoom = new ChatRoomDto();
-		long stopTime;
-		if (!chatRepository.existsByUserId(user.getId())) {
-			log.info("[createRoom] roomId 값이 없음");
-			chatRoom = ChatRoomDto.create(nickname);
-			ChatRoomMap.getInstance().getChatRooms().put(chatRoom.getRoomId(), chatRoom);
-			Chat chat = new Chat(chatRoom.getRoomId(), user);
-			chatRepository.save(chat);
-			stopTime = System.currentTimeMillis();
-			log.info("readFile : " + (stopTime - startTime) + " 초");
-			return chatRoom;
-		} else {
-			log.info("[createRoom] roomId 값은 있지만 cache 적용 안됨");
-			Optional<Chat> findChat = chatRepository.findByUserId(user.getId());
-			chatRoom.setRoomId(findChat.get().getRoomId());
-			if (!isChatFileExists(findChat.get().getRoomId())) {
-				return null;
-			}
-			List<String> lastLine = lastLine(findChat.get().getRoomId());
-			if (lastLine == null || lastLine.isEmpty()) {
-				return null;
-			}
-			stopTime = System.currentTimeMillis();
-			log.info("readFile : " + (stopTime - startTime) + " 초");
-			return ChatRoomDto.of(findChat.get().getRoomId(), nickname, user, lastLine);
-		}
-	}
+    public void connectUser(String status, String roomId, ChatMessage chatMessage) {
+        log.info("[ connectUser ] roomId : " + roomId);
+        int num = 0;
+        synchronized (lock) {
+            if (Objects.equals(status, "Connect")) {
+                num = connectUsers.getOrDefault(roomId, 0);
+                connectUsers.put(roomId, (num + 1));
+                saveFile(chatMessage);
+            } else if (Objects.equals(status, "Disconnect")) {
+                num = connectUsers.get(roomId);
+                connectUsers.put(roomId, (num - 1));
+            }
+            log.info("현재 인원 : " + connectUsers.get(roomId));
+        }
+    }
 
-	private boolean isChatFileExists(String roomId) {
-		String filePath = chatUploadLocation + "/" + roomId + ".txt";
-		File file = new File(filePath);
-		return file.exists();
-	}
+    //채팅방 불러오기
+    public List<ChatRoomDto> findAllRoom() {
+        List<ChatRoomDto> chatRoomDtos = new ArrayList<>();
+        List<Chat> all = chatRepository.findAll();
+        try {
+            for (int i = 0; i < all.size(); i++) {
+                User user = userRepository.findById(all.get(i).getUser().getId()).orElseThrow(UserNotFoundException::new);
+                chatRoomDtos.add(ChatRoomDto.of(all.get(i).getRoomId(), user, lastLine(all.get(i).getRoomId())));
+            }
+        } catch (NullPointerException e) {
+            log.info(" [현재 채팅방 db 없음!] " + e);
+        }
+        return chatRoomDtos;
+    }
 
-	// 파일 저장
-	public void saveFile(ChatMessage chatMessage) {
-		if (connectUsers.get(chatMessage.getRoomId()) != 0) {
-			if (chatMessage.getType() == ChatMessage.MessageType.JOIN) {
-				reset(chatMessage.getSender(), chatMessage.getRoomId());
-			} else {
-				countChat(chatMessage.getSender(), chatMessage.getRoomId());
-			}
-		}
+    //채팅방 생성
+    @CachePut(key = "#nickname", value = "createRoom", unless = "#result == null", cacheManager = "cacheManager")
+    public ChatRoomDto createRoom(String nickname) {
+        long startTime = System.currentTimeMillis();
+        User user = userRepository.findByNickname(nickname).orElseThrow(UserNotFoundException::new);
+        ChatRoomDto chatRoom = new ChatRoomDto();
+        long stopTime;
+        if (!chatRepository.existsByUserId(user.getId())) {
+            log.info("[createRoom] roomId 값이 없음");
+            chatRoom = ChatRoomDto.create(nickname);
+            ChatRoomMap.getInstance().getChatRooms().put(chatRoom.getRoomId(), chatRoom);
+            Chat chat = new Chat(chatRoom.getRoomId(), user);
+            chatRepository.save(chat);
+            stopTime = System.currentTimeMillis();
+            log.info("readFile : " + (stopTime - startTime) + " 초");
+            return chatRoom;
+        } else {
+            log.info("[createRoom] roomId 값은 있지만 cache 적용 안됨");
+            Optional<Chat> findChat = chatRepository.findByUserId(user.getId());
+            String roomId = findChat.get().getRoomId();
+            chatRoom.setRoomId(findChat.get().getRoomId());
 
-		LocalDateTime now = LocalDateTime.now();
-		int month = now.getMonthValue();
-		int day = now.getDayOfMonth();
-		String pattern = "HH:mm";
-		String time = LocalDateTime.now().format(DateTimeFormatter.ofPattern(pattern));
+            if (!isChatFileExists(roomId)) {
+                return null;
+            }
 
-		JsonObject jsonObject = new JsonObject();
-		jsonObject.addProperty("roomId", chatMessage.getRoomId());
-		if (chatMessage.getType() == ChatMessage.MessageType.JOIN) {
-			jsonObject.addProperty("type", "JOINED");
-		} else {
-			jsonObject.addProperty("type", chatMessage.getType().toString());
-		}
-		Integer adminCnt = adminChat.get(chatMessage.getRoomId());
-		Integer userCnt = adminChat.get(chatMessage.getRoomId());
-		String days = month + "/" + day;
+            LastMessage lastLine = lastLine(roomId);
+            if (lastLine == null) {
+                return null;
+            }
+            stopTime = System.currentTimeMillis();
+            log.info("readFile : " + (stopTime - startTime) + " 초");
+            return ChatRoomDto.of(roomId, user, lastLine);
+        }
+    }
 
-		jsonObject.addProperty("sender", chatMessage.getSender());
-		jsonObject.addProperty("message", chatMessage.getMessage());
-		jsonObject.addProperty("adminChat", adminCnt);
-		jsonObject.addProperty("userChat", userCnt);
-		jsonObject.addProperty("day", days);
-		jsonObject.addProperty("time", time);
+    private boolean isChatFileExists(String roomId) {
+        String filePath = chatUploadLocation + "/" + roomId + ".txt";
+        File file = new File(filePath);
+        return file.exists();
+    }
 
-		LastMessage lastMessage = LastMessage.of(chatMessage, adminCnt, userCnt, days, time);
-		lastMessageMap.put(chatMessage.getRoomId(), lastMessage);
+    public ChatMessage chatAlarm(String sender, String roomId) {
+        ChatMessage chatMessage = new ChatMessage();
+        if (Objects.equals(sender, "admin") && connectUsers.get(roomId) == 1) {
+            chatMessage.setRoomId(roomId);
+            chatMessage.setSender(sender);
+            chatMessage.setMessage("고객센터에 문의한 글에 답글이 달렸습니다.");
+            return chatMessage;
+        } else if (!Objects.equals(sender, "admin") && connectUsers.get(roomId) == 1) {
+            chatMessage.setRoomId(roomId);
+            chatMessage.setSender(sender);
+            chatMessage.setMessage(sender + " 님이 답을 기다리고 있습니다.");
+            return chatMessage;
+        } else {
+            return chatMessage;
+        }
+    }
 
-		Gson gson = new Gson();
-		String json = gson.toJson(jsonObject);
+    // 파일 저장
+    public void saveFile(ChatMessage chatMessage) {
+        if (connectUsers.get(chatMessage.getRoomId()) != 0) {
+            if (chatMessage.getType() == MessageType.JOIN) {
+                reset(chatMessage.getSender(), chatMessage.getRoomId());
+            } else {
+                countChat(chatMessage.getSender(), chatMessage.getRoomId());
+            }
+        }
 
-		try (PrintWriter out = new PrintWriter(new BufferedWriter(new FileWriter(chatUploadLocation + "/" + chatMessage.getRoomId() + ".txt", true)))) {
-			if (new File(chatUploadLocation + "/" + chatMessage.getRoomId() + ".txt").length() == 0) {
-				out.println(json);
-				chatAlarm(chatMessage.getSender(), chatMessage.getRoomId());
-			} else {
-				out.println("," + json);
-			}
-		} catch (IOException e) {
-			log.error("[error] " + e);
-		}
-	}
+        LocalDateTime now = LocalDateTime.now();
+        int month = now.getMonthValue();
+        int day = now.getDayOfMonth();
+        String pattern = "HH:mm";
+        String time = LocalDateTime.now().format(DateTimeFormatter.ofPattern(pattern));
 
-	public Object readFile(String roomId) {
-		long startTime = System.currentTimeMillis();
-		String filePath = chatUploadLocation + "/" + roomId + ".txt";
-		File file = new File(filePath);
-		if (!file.exists()) {
-			try {
-				file.createNewFile();
-			} catch (IOException e) {
-				log.error("[error] " + e);
-				return null;
-			}
-		}
-		try {
-			List<String> lines = Files.lines(file.toPath()).collect(Collectors.toList());
-			String jsonString = "[" + String.join(",", lines) + "]";
-			JSONParser parser = new JSONParser();
-			Object obj = parser.parse(jsonString);
-			long stopTime = System.currentTimeMillis();
-			log.info("readFile : " + (stopTime - startTime) + " 초");
-			return obj;
-		} catch (NoSuchFileException e) {
-			throw new FileNotFoundException();
-		} catch (IOException | ParseException e) {
-			log.error("[error] " + e);
-			return null;
-		}
-	}
+        JsonObject jsonObject = new JsonObject();
+        jsonObject.addProperty("roomId", chatMessage.getRoomId());
+        if (chatMessage.getType() == MessageType.JOIN) {
+            jsonObject.addProperty("type", "JOINED");
+        } else {
+            jsonObject.addProperty("type", chatMessage.getType().toString());
+        }
+        Integer adminCnt = adminChat.get(chatMessage.getRoomId());
+        Integer userCnt = adminChat.get(chatMessage.getRoomId());
+        String days = month + "/" + day;
 
-	public void reset(String sender, String roomId){
-		if (sender.equals("admin")){
-			adminChat.putIfAbsent(roomId, 0);
-			userChat.putIfAbsent(roomId, 0);
-			adminChat.put(roomId,0);
-		} else {
-			userChat.putIfAbsent(roomId, 0);
-			adminChat.putIfAbsent(roomId, 0);
-			userChat.put(roomId,0);
-		}
-	}
+        jsonObject.addProperty("sender", chatMessage.getSender());
+        jsonObject.addProperty("message", chatMessage.getMessage());
+        jsonObject.addProperty("adminChat", adminCnt);
+        jsonObject.addProperty("userChat", userCnt);
+        jsonObject.addProperty("day", days);
+        jsonObject.addProperty("time", time);
 
-	public void countChat(String sender, String roomId){
-		if(sender.equals("admin")) {
-			userChat.putIfAbsent(roomId, 0);
-			int num = userChat.get(roomId);
-			userChat.put(roomId, num+1);
-			adminChat.put(roomId,0);
-		}
-		else {
-			adminChat.putIfAbsent(roomId, 0);
-			int num = adminChat.get(roomId);
-			adminChat.put(roomId, num+1);
-			userChat.put(roomId,0);
-		}
-	}
-	public List<String> lastLine(String roomId) {
-		String filePath = chatUploadLocation + "/" + roomId + ".txt";
-		File file = new File(filePath);
-		if (!file.exists()) {
-			try {
-				file.createNewFile();
-				return Collections.emptyList();
-			} catch (IOException e) {
-				e.printStackTrace();
-				return Collections.emptyList();
-			}
-		}
-		try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r")) {
+        LastMessage lastMessage = LastMessage.of(chatMessage, adminCnt, userCnt, days, time);
+        lastMessageMap.put(chatMessage.getRoomId(), lastMessage);
 
-			long fileLength = file.length();
-			if (fileLength <= 0) {
-				return Collections.emptyList();
-			}
-			randomAccessFile.seek(fileLength);
-			long pointer = fileLength - 2;
-			while (pointer > 0) {
-				randomAccessFile.seek(pointer);
-				char c = (char) randomAccessFile.read();
-				if (c == '\n') {
-					break;
-				}
-				pointer--;
-			}
-			randomAccessFile.seek(pointer + 1);
-			String line = randomAccessFile.readLine();
-			if (line == null || line.trim().isEmpty()) {
-				return Collections.emptyList();
-			}
-			if (line.startsWith(",")) {
-				line = line.substring(1);
-			}
+        Gson gson = new Gson();
+        String json = gson.toJson(jsonObject);
 
-			JsonParser parser = new JsonParser();
-			JsonObject json = parser.parse(line).getAsJsonObject();
-			int adminChat = json.get("adminChat").getAsInt();
-			int userChat = json.get("userChat").getAsInt();
-			String message = json.get("message").getAsString().trim();
-			String messages = new String(message.getBytes("iso-8859-1"), "utf-8");
+        try (PrintWriter out = new PrintWriter(new BufferedWriter(new FileWriter(chatUploadLocation + "/" + chatMessage.getRoomId() + ".txt", true)))) {
+            if (new File(chatUploadLocation + "/" + chatMessage.getRoomId() + ".txt").length() == 0) {
+                out.println(json);
+                chatAlarm(chatMessage.getSender(), chatMessage.getRoomId());
+            } else {
+                out.println("," + json);
+            }
+        } catch (IOException e) {
+            log.error("[error] " + e);
+        }
+    }
 
-			List<String> chat = new ArrayList<>();
-			chat.add(Integer.toString(adminChat));
-			chat.add(Integer.toString(userChat));
-			chat.add(messages);
-			return chat;
-		} catch (IOException | JsonSyntaxException e) {
-			e.printStackTrace();
-			return Collections.emptyList();
-		}
-	}
 
-	public ChatMessage chatAlarm(String sender, String roomId){
-		ChatMessage chatMessage = new ChatMessage();
-		if (Objects.equals(sender, "admin") && connectUsers.get(roomId) ==1){
-			chatMessage.setRoomId(roomId);
-			chatMessage.setSender(sender);
-			chatMessage.setMessage("고객센터에 문의한 글에 답글이 달렸습니다.");
-		} else if (!Objects.equals(sender, "admin") && connectUsers.get(roomId) == 1) {
-			chatMessage.setRoomId(roomId);
-			chatMessage.setSender(sender);
-			chatMessage.setMessage(sender + " 님이 답을 기다리고 있습니다.");
+    public void reset(String sender, String roomId) {
+        if (sender.equals("admin")) {
+            adminChat.putIfAbsent(roomId, 0);
+            userChat.putIfAbsent(roomId, 0);
+            adminChat.put(roomId, 0);
+        } else {
+            userChat.putIfAbsent(roomId, 0);
+            adminChat.putIfAbsent(roomId, 0);
+            userChat.put(roomId, 0);
+        }
+    }
 
-		}
-		return chatMessage;
-	}
+    public void countChat(String sender, String roomId) {
+        if (sender.equals("admin")) {
+            userChat.putIfAbsent(roomId, 0);
+            int num = userChat.get(roomId);
+            userChat.put(roomId, num + 1);
+            adminChat.put(roomId, 0);
+        } else {
+            adminChat.putIfAbsent(roomId, 0);
+            int num = adminChat.get(roomId);
+            adminChat.put(roomId, num + 1);
+            userChat.put(roomId, 0);
+        }
+    }
+
+    public Object readFile(String roomId) {
+        long startTime = System.currentTimeMillis();
+        String filePath = chatUploadLocation + "/" + roomId + ".txt";
+        File file = new File(filePath);
+        if (!file.exists()) {
+            try {
+                // 파일이 존재하지 않는 경우 새로 생성
+                file.createNewFile();
+            } catch (IOException e) {
+                log.error("[error] " + e);
+                return null;
+            }
+        }
+        try {
+            List<String> lines = Files.lines(file.toPath()).collect(Collectors.toList());
+            String jsonString = "[" + String.join(",", lines) + "]";
+            JSONParser parser = new JSONParser();
+            Object obj = parser.parse(jsonString);
+            long stopTime = System.currentTimeMillis();
+            log.info("readFile : " + (stopTime - startTime) + " 초");
+            return obj;
+        } catch (NoSuchFileException e) {
+            throw new FileNotFoundException();
+        } catch (IOException | ParseException e) {
+            log.error("[error] " + e);
+            return null;
+        }
+    }
+
+    public LastMessage lastLine(String roomId) {
+        if (lastMessageMap.containsKey(roomId)) {
+            log.info(" = = = MAP 활용 = = = ");
+            return lastMessageMap.get(roomId);
+        } else {
+            log.info(" = = = MAP 활용 X = = = ");
+            String filePath = chatUploadLocation + "/" + roomId + ".txt";
+            File file = new File(filePath);
+            // 파일의 존재 여부 확인
+            if (!file.exists()) {
+                try {
+                    // 파일이 존재하지 않는 경우 새로 생성
+                    file.createNewFile();
+                    return null;
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    return null;
+                }
+            }
+            try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r")) {
+
+                long fileLength = file.length();
+                if (fileLength <= 0) {
+                    return null;
+                }
+                randomAccessFile.seek(fileLength);
+                long pointer = fileLength - 2;
+                while (pointer > 0) {
+                    randomAccessFile.seek(pointer);
+                    char c = (char) randomAccessFile.read();
+                    if (c == '\n') {
+                        break;
+                    }
+                    pointer--;
+                }
+                randomAccessFile.seek(pointer + 1);
+                String line = randomAccessFile.readLine();
+                if (line == null || line.trim().isEmpty()) {
+                    return null;
+                }
+                if (line.startsWith(",")) {
+                    line = line.substring(1);
+                }
+
+                JsonParser parser = new JsonParser();
+                JsonObject json = parser.parse(line).getAsJsonObject();
+                int adminChat = json.get("adminChat").getAsInt();
+                int userChat = json.get("userChat").getAsInt();
+                String message = json.get("message").getAsString().trim();
+                String messages = new String(message.getBytes("iso-8859-1"), "utf-8");
+                String day = json.get("day").getAsString();
+                String time = json.get("time").getAsString();
+
+                ChatMessage chatMessage = new ChatMessage();
+                chatMessage.setRoomId(roomId);
+                chatMessage.setMessage(messages);
+                return LastMessage.of(chatMessage, adminChat, userChat, day, time);
+            } catch (IOException | JsonSyntaxException e) {
+                e.printStackTrace();
+                return null;
+            }
+        }
+    }
 }


### PR DESCRIPTION
#### 채팅방을 실행하면 가장 마지막 채팅 기록(한줄만) 가져올 때 코드 수정(카카오톡 채팅방 목록 생각하면 됨)

- 요약 : 파일을 계속 열어서 글을 읽는 횟수를 줄임

- 기존 : 파일을 열어서 마지막 글 가져옴

- 수정 후 : 최초 채팅방 실행 때만 파일을 열어서 마지막 글을 가져오고 이후에 채팅을 시작하면       
파일을 저장할 때 따로 값을 저장한 다음 가져오게 하여 시간을 단축함