### PR TITLE
[기능 개선] Batch reader 방법 개선

### DIFF
--- a/src/main/java/com/dalcho/adme/domain/VideoFile.java
+++ b/src/main/java/com/dalcho/adme/domain/VideoFile.java
@@ -63,7 +63,6 @@ public class VideoFile extends Timestamped {
     public void update(VideoFile updateVideoFile) {
         updateTitle(updateVideoFile.getTitle());
         updateContent(updateVideoFile.getContent());
-        updateVideoDate(updateVideoFile.getVideoDate());
     }
 
     public void updateTitle(String title) {
@@ -75,12 +74,6 @@ public class VideoFile extends Timestamped {
     public void updateContent(String content) {
         if (content != null) {
             this.content = content;
-        }
-    }
-
-    public void updateVideoDate(LocalDateTime videoDate) {
-        if (videoDate != null) {
-            this.videoDate = videoDate;
         }
     }
 

--- a/src/main/java/com/dalcho/adme/dto/video/VideoRequestDto.java
+++ b/src/main/java/com/dalcho/adme/dto/video/VideoRequestDto.java
@@ -28,7 +28,7 @@ public class VideoRequestDto {
                 .s3FileName(s3FileName)
                 .s3ThumbnailUrl(s3ThumbnailUrl)
                 .s3TenVideoUrl(s3TenVideoUrl)
-                .videoDate(LocalDateTime.now())
+                .videoDate(LocalDateTime.now().plusMinutes(10))
                 .build();
     }
 


### PR DESCRIPTION
Batch 의 reader 과정 개선
변경점.
    - Paging 첫페이지만 조회
    - 쿼리 변경 : "SELECT vf FROM VideoFile vf WHERE video_date <= CURRENT_TIMESTAMP AND status = 'valid' order by created_at desc"
    - video_data에 미리 +10분을 계산한 값을 넣고 해당 값과 현재시간을 비교해 10분이 지난 데이터만 읽어오도록 하였습니다.
    - status 값으로 해당 데이터가 이미 배치를 거쳤는지 체크